### PR TITLE
Resolves the Issue with Upload and Update Endpoint

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -146,3 +146,5 @@ async def delete_files(key: str):
         raise HTTPException(status_code=404, detail="Folder not found")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error deleting folder: {str(e)}")
+    
+    return {"message": f"Folder '{key}' and its contents deleted successfully"}

--- a/server/main.py
+++ b/server/main.py
@@ -2,7 +2,7 @@ import shutil
 from fastapi import FastAPI, HTTPException, Form
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
-from typing import Optional, List
+from typing import Optional
 from app.crud.crud import check_key_existence,create_connection,create_image_metadata, get_metadata, delete_metadata,db_file
 import os
 import string
@@ -26,26 +26,27 @@ def generate_random_string(length=8):
     return ''.join(random.choice(letters) for _ in range(length))
 
 @app.post("/upload/")
-async def upload(key: Optional[str] = Form(None), encoded_content: List[str] = Form(...)):
+async def upload(key: Optional[str] = Form(None), encoded_content: str = Form(...)):
     try:
         if not key:
             key = generate_random_string()
         if not encoded_content:
             raise HTTPException(status_code=422, detail="Field 'encoded_content' cannot be empty")
-        if check_key_existence(key):
-            raise HTTPException(status_code=404, detail="Key already exist")
         key_directory = f"{key}"
         directory_key = f"./storage/{key_directory}"
-        os.makedirs(directory_key , exist_ok=True)
-        for i, encoded_item in enumerate(encoded_content, start= 1):
-                output_file_path = os.path.join(directory_key, f'encodedtxt{i}.txt')
+        os.makedirs(directory_key, exist_ok=True)
+        
+        separated_strings = encoded_content.split(',')
+        existing_files_count = len([name for name in os.listdir(directory_key) if name.startswith("encodedtxt")])
+        
+        for i, encoded_item in enumerate(separated_strings, start=existing_files_count + 1):
+            output_file_path = os.path.join(directory_key, f'encodedtxt{i}.txt')
 
-                with open(output_file_path, 'wb') as output_file:
-                    output_file.write(encoded_item.encode())
-        create_image_metadata( key, key_directory)
-        return JSONResponse(content={"message": "File uploaded successfully","key": key})
-    except HTTPException as http_exc:
-        raise http_exc
+            with open(output_file_path, 'w') as output_file:
+                output_file.write(f"{encoded_item}")
+                
+        create_image_metadata(key, key_directory)
+        return JSONResponse(content={"message": "Files uploaded successfully", "key": key})
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -74,7 +75,8 @@ async def retrieve_file(key: str, metadata_only: Optional[bool] = False):
         return binary_data_list
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e))   
+    
 
 @app.put("/update/")
 async def update_files(key: str, encoded_content: str = Form(...), new_key: Optional[str] = Form(None)):
@@ -130,10 +132,6 @@ async def update_files(key: str, encoded_content: str = Form(...), new_key: Opti
                     output_file.write(encoded_item)
 
             return JSONResponse(content={"message": "Files updated successfully"})
-        
-    except HTTPException as http_exc:
-        raise http_exc
-    
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -148,5 +146,5 @@ async def delete_files(key: str):
         raise HTTPException(status_code=404, detail="Folder not found")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error deleting folder: {str(e)}")
-
+    
     return {"message": f"Folder '{key}' and its contents deleted successfully"}

--- a/server/main.py
+++ b/server/main.py
@@ -46,7 +46,7 @@ async def upload(key: Optional[str] = Form(None), encoded_content: str = Form(..
                 output_file.write(f"{encoded_item}")
                 
         create_image_metadata(key, key_directory)
-        return JSONResponse(content={"message": "Files uploaded successfully", "key": key})
+        return JSONResponse(content={"message": "File uploaded successfully", "key": key})
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -92,8 +92,8 @@ async def update_files(key: str, encoded_content: str = Form(...), new_key: Opti
             new_key_directory = f"./storage/{new_key}"
             os.makedirs(new_key_directory, exist_ok=True)
             create_image_metadata(new_key, new_key_directory)
-            path = f"./storage/{get_metadata(key)}"
-            new_path = new_key_directory
+            new_filepath = get_metadata(new_key)
+            new_path = f"./storage/{new_filepath}" if new_filepath else new_key_directory
 
             for filename in os.listdir(path):
                 source_file_path = os.path.join(path, filename)
@@ -132,8 +132,10 @@ async def update_files(key: str, encoded_content: str = Form(...), new_key: Opti
                     output_file.write(encoded_item)
 
             return JSONResponse(content={"message": "Files updated successfully"})
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="File not found")
+
 
 @app.delete("/delete/")
 async def delete_files(key: str):

--- a/server/tests/test.py
+++ b/server/tests/test.py
@@ -78,7 +78,7 @@ def test_update_files_success():
     response = client.put(f"/update/?key={key}&new_key={new_key}", data={"encoded_content": encoded_content})
     assert response.status_code == 200
     assert response.json() == {"message": "Files updated successfully"}
-
+    
 def test_update_files_no_key_found():
     key = "non_existent_key"
     new_key = "new_test_key"


### PR DESCRIPTION
Resolves the Issue with Upload and Update Endpoint

- The Issue with the Upload endpoint was, it was replacing the previous base64 string with newer ones and suppose if the  multiple string are provided. Then it was taking it as single string with comma separated. for eg "string1, string2" in the Single "encodedtxt file".
- So, I've fixed this Issue and now for the multiple string. For each Comma separated string is taken and creates the separate "encodedtxt file" for each.
-  Where as, In Update endpoint, even though it was creating the separate "encodedtxt file for each iteartion". but couldn't able to create the separate "encodedtxt file if the multiple strings are provided at a time". Thus, it fixes that too.

Closes #34 