### PR TITLE
Fixed upload overridng of files and added docker guide in docs.md

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -30,7 +30,93 @@ uvicorn main:app --reload
 Once the app is successfully installed, access http://127.0.0.1:8000/docs, You'll see a screen similar to the below screen shot
 <img width="1617" alt="image" src="https://github.com/cia-labs/Storage-service/assets/41864599/e8774034-5a50-4e82-9e4b-c3e84c47bdf9">
 
+---
+---
 
+# Deploying the Storage Service as a Docker Container
 
+To deploy the storage service as a container, follow these steps:
+
+## **Create a Dockerfile:**
+
+Create a file named Dockerfile in the root directory of your project and add the following content:
+```docker
+# Use the latest version of Alpine as the base image
+FROM alpine:latest
+
+# Set the working directory inside the container
+WORKDIR /code
+
+# Copy all files from directory to /code
+COPY . /code
+
+# Install Python and pip in the Alpine image
+RUN apk --no-cache add python3 py3-pip
+
+# Set up a virtual environment
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+# Expose port 8000
+EXPOSE 8000
+
+# Upgrade pip and install the required packages
+RUN pip install --upgrade pip && pip install -r requirements.txt  
+
+# Specify the command to run the application
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000","--reload"]
+
+```
+## **Build the Docker Image:**
+
+In the terminal, navigate to the directory containing the Dockerfile and run the following command to build the Docker image. Replace your_image_name:tag with a name and tag for your image.
+
+```bash
+docker build -t your_image_name:tag .
+ ```
+
+## **Upload the Docker Image to Docker Hub:**
+
+If you haven't done so already, create an account on Docker Hub. After creating an account, log in to Docker Hub in the terminal using the following command:
+    
+```bash
+docker login
+```
+
+Tag the built image with your Docker Hub username and the desired repository name:
+```bash
+docker tag your_image_name:tag your_dockerhub_username/repository_name:tag
+```
+Push the image to Docker Hub:
+
+```bash
+docker push your_dockerhub_username/repository_name:tag
+```
+## **Pull and Deploy the Docker Image:**
+
+On the machine where you want to deploy the storage service, ensure that Docker is installed. Pull the Docker image from Docker Hub:
+
+```bash
+docker pull your_dockerhub_username/repository_name:tag
+```
+Run the container from the pulled image:
+```
+docker run -p host_port:container_port your_dockerhub_username/repository_name:tag
+```
+
+Replace host_port with the port on your host machine where you want to expose the service, and container_port with the port specified in the Dockerfile (in this case, 8000).
+
+Now, the storage service should be running inside the Docker container. Access it through the specified host port on your machine.
+
+Note: If you want to change the exposed port, modify the EXPOSE and CMD directives in the Dockerfile. Update the EXPOSE line with the desired port, and adjust the --port option in the CMD line accordingly.
+
+```docker
+    # Change the exposed port to 8080
+EXPOSE 8080
+
+    # Change the CMD line to use port 8080
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080","--reload"]
+```
+    
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -32,16 +32,20 @@ async def upload(key: Optional[str] = Form(None), encoded_content: List[str] = F
             key = generate_random_string()
         if not encoded_content:
             raise HTTPException(status_code=422, detail="Field 'encoded_content' cannot be empty")
+        if check_key_existence(key):
+            raise HTTPException(status_code=404, detail="Key already exist")
         key_directory = f"{key}"
         directory_key = f"./storage/{key_directory}"
         os.makedirs(directory_key , exist_ok=True)
-        for i, encoded_items in enumerate(encoded_content, start=1):
+        for i, encoded_item in enumerate(encoded_content, start= 1):
                 output_file_path = os.path.join(directory_key, f'encodedtxt{i}.txt')
 
                 with open(output_file_path, 'wb') as output_file:
-                    output_file.write(encoded_items.encode())
+                    output_file.write(encoded_item.encode())
         create_image_metadata( key, key_directory)
         return JSONResponse(content={"message": "File uploaded successfully","key": key})
+    except HTTPException as http_exc:
+        raise http_exc
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -70,7 +74,7 @@ async def retrieve_file(key: str, metadata_only: Optional[bool] = False):
         return binary_data_list
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))   
+        raise HTTPException(status_code=500, detail=str(e))
 
 @app.put("/update/")
 async def update_files(key: str, encoded_content: List[str] = Form(...), new_key: Optional[str] = Form(None)):

--- a/server/tests/test.py
+++ b/server/tests/test.py
@@ -12,7 +12,8 @@ from main import app
 
 client = TestClient(app)
 
-def test_upload_success():
+def test_upload_retrieve():
+    #test for upload sucess
     key = None  
     encoded_content = ["encoded_content_1", "encoded_content_2"]
     
@@ -24,10 +25,10 @@ def test_upload_success():
     generated_key = response_data.get("key", None)
     assert response_data == {"message": "File uploaded successfully", "key": generated_key}
 
-def test_upload_fail():
+    #test for failue of upload
     response = client.post(
         "/upload/",
-        data={"key": "testkey", "encoded_content": []}
+        data={"key": "test", "encoded_content": []}
     )
     print(response.json())
     assert response.status_code == 422
@@ -42,12 +43,8 @@ def test_upload_fail():
             }
         ]
     }
-
-def test_retrieve_file_success():
-
-    key = "test_key"
-    encoded_content = ["encoded_content_1", "encoded_content_2"]
-    client.post("/upload/", data={"key": key, "encoded_content": encoded_content})
+    # test for retreive 
+    key = generated_key
 
     response = client.get(f"/get/{key}")
     print(response.status_code)
@@ -55,7 +52,7 @@ def test_retrieve_file_success():
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
-def test_retrieve_file_key_not_found():
+#test for failure of retrieve
     non_existent_key = "nonexistentkey"
 
     response = client.get(f"/get/{non_existent_key}")
@@ -65,40 +62,29 @@ def test_retrieve_file_key_not_found():
 
     assert response.status_code == 500
     assert response.json() == {'detail': '404: Key not found'}
-
-
-def test_update_files_success():
-    key = "test_key"
+#test for update sucess
+    key = generated_key
     new_key = "new_test_key"
-    encoded_content = ["encoded_content_1", "encoded_content_2"]
-
-    response = client.post("/upload/", data={"key": key, "encoded_content": encoded_content})
-    assert response.status_code == 200
+    encoded_content = ["encoded_content_3", "encoded_content_4"]
 
     response = client.put(f"/update/?key={key}&new_key={new_key}", data={"encoded_content": encoded_content})
     assert response.status_code == 200
     assert response.json() == {"message": "Files updated successfully"}
-
-def test_update_files_no_key_found():
+#test for failure of update
     key = "non_existent_key"
-    new_key = "new_test_key"
-    encoded_content = ["encoded_content_1", "encoded_content_2"]
+    new_key = "new_key"
+    encoded_content = ["encoded_content_3", "encoded_content_4"]
 
     response = client.put(f"/update/?key={key}&new_key={new_key}", data={"encoded_content": encoded_content})
     assert response.status_code == 404
     assert response.json() == {"detail": "Key not found"}
-
-def test_delete_files_success():
-    key = "test_key"
-    encoded_content = ["encoded_content_1", "encoded_content_2"]
-
-    client.post("/upload/", data={"key": key, "encoded_content": encoded_content})
+#test for delete sucess
+    key = generated_key
 
     response = client.delete(f"/delete/?key={key}")
     assert response.status_code == 200
     assert response.json() == {"message": f"Folder '{key}' and its contents deleted successfully"}
-
-def test_delete_files_no_key_found():
+#test for failure of delete
     non_existent_key = "non_existent_key"
 
     response = client.delete(f"/delete/?key={non_existent_key}")


### PR DESCRIPTION
- closes #34 
- fixed the upload overriding old files when the same key is used 
- added the documentation for creating docker container in docs.md
- Also modified the tes.py to have single test , the reason being
the test.py had a conflict with the updated upload endpoint code
Unnecessary multiple tests
different test cases created and requested multiple uploads , dialed that down to one or two and performing of update and delete is now performed on a single key rather than creating a new key each time.